### PR TITLE
Fixes for minor issues I ran into when using the plugin

### DIFF
--- a/template/package.json.tt
+++ b/template/package.json.tt
@@ -1,6 +1,7 @@
 {
   "name": "<%= Rails.application.class.parent_name %>",
   "version": "0.0.0",
+  "private": true,
   "scripts": {
     "start": "$(npm bin)/webpack-dev-server --hot"
   },
@@ -25,5 +26,5 @@
     "webpack-dev-server": "^1.10.1",
     "webpack-stream": "^2.0.0",
     "react-hot-loader": "^1.2.8"
-  },
+  }
 }


### PR DESCRIPTION
First fix is simply taking out the trailing comma in the `package.json` file: 

Second change, providing the `"private": true` option, is just to avoid seeing these npm warnings:

```
npm WARN package.json FoxyDashboardRails@0.0.0 No repository field.
npm WARN package.json FoxyDashboardRails@0.0.0 No license field.
```
